### PR TITLE
Build the .deb file in a docker container.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,11 @@ matrix:
         -   env: TOXENV=py36
             python: 3.6
 install: pip install coveralls tox
-script: tox
+script:
+    - tox
+    - make itest_trusty
+    - make itest_xenial
+    - make itest_bionic
 after_success: coveralls
 cache:
     directories:

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,12 @@ DEB_NAME := docker-push-latest-if-changed_$(VERSION)_all.deb
 
 .PHONY: builddeb
 builddeb:
-	mkdir -p dist
-	debuild -us -uc -b
-	mv ../$(DEB_NAME) dist/
+	docker build -f builddeb.Dockerfile -t builddeb .
+	mkdir -p dist/
+	docker run \
+		-v $(CURDIR):/mnt:rw \
+		builddeb \
+	/bin/bash -c "debuild -us -uc -b && mv ../$(DEB_NAME) /mnt/dist"
 
 .PHONY: itest_%
 itest_%: builddeb

--- a/builddeb.Dockerfile
+++ b/builddeb.Dockerfile
@@ -1,0 +1,9 @@
+FROM        ubuntu:bionic
+RUN         apt-get update && apt-get install -y --no-install-recommends \
+                build-essential \
+                debhelper \
+                devscripts \
+                fakeroot \
+            && apt-get clean
+
+WORKDIR     /mnt

--- a/docker_push_latest_if_changed.py
+++ b/docker_push_latest_if_changed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 import argparse
 import hashlib
 import subprocess

--- a/itest
+++ b/itest
@@ -4,10 +4,10 @@ set -euo pipefail
 path="$1"
 
 apt-get update
-apt-get -y install --no-install-recommends gdebi-core software-properties-common
+apt-get -y install --no-install-recommends software-properties-common
 add-apt-repository ppa:deadsnakes/ppa
 
 apt-get update
-gdebi -n "$path"
+apt install -y "$path"
 
 docker-push-latest-if-changed --help


### PR DESCRIPTION
Ensure Python3.6 for f-string and inline type
annotation compatibility.

Adding this because the host won't necessarily have the packages required to build the `.deb` (at least that's what happened in my case). Though in the end it just swaps the host dependencies to docker rather than the whatever packages are needed to run `debuild`.

Had to stop using `gdebi` in the itest because `debuild` on ubuntu bionic would create a `.deb` file with a control zipped as `.xz`:
```
andytran@dev13-uswest1cdevc:~/pg/docker_push_latest_if_changed/docker-push-latest-if-changed/dist (build-deb-in-a-container) $ ar -x docker-push-latest-if-changed_0.0.0_all.deb
andytran@dev13-uswest1cdevc:~/pg/docker_push_latest_if_changed/docker-push-latest-if-changed/dist (build-deb-in-a-container) $ ls
control.tar.xz  data.tar.xz  debian-binary  docker-push-latest-if-changed_0.0.0_all.deb
```

Trying to install this `.deb` file with `gdebi` on ubuntu xenial would result in a cryptic error:
```
Reading package lists...
Reading package lists... Done
Building dependency tree
Reading state information... Done
Traceback (most recent call last):
  File "/usr/bin/gdebi", line 86, in <module>
    if not debi.open(args[0]):
  File "/usr/share/gdebi/GDebi/GDebiCli.py", line 73, in open
    self._deb = DebPackage(file, self._cache)
  File "/usr/share/gdebi/GDebi/DebPackage.py", line 31, in __init__
    super(DebPackage, self).__init__(cache=cache, filename=filename)
  File "/usr/lib/python3/dist-packages/apt/debfile.py", line 61, in __init__
    self.open(filename)
  File "/usr/lib/python3/dist-packages/apt/debfile.py", line 71, in open
    control = self._debfile.control.extractdata("control")
LookupError: There is no member named 'control'
make: *** [itest_xenial] Error 1
```

After further digging, I found that when it was trying to unzip control, it was attempting to unzip it using the default `gzip`. There doesn't seem to be any exposed parameter to override using `xz` instead, so I decided to just forsake `gdebi`. `apt install` seems to do what we want (install the `.deb` while also installing its dependencies) without encountering this issue so I used that instead.

If we really want to use `gdebi` though, one way to get around this issue is to force using `gzip` when building the `.deb` file by adding this to `debian/rules`:
```
override_dh_builddeb:
    dh_builddeb -- -Zgzip
```