### PR TITLE
Remove [testenv:venv] now that `tox --devenv` is a thing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,5 @@ commands =
     pre-commit run --all-files
     mypy docker_push_latest_if_changed.py testing
 
-[testenv:venv]
-envdir = venv
-language_version = /usr/bin/python3.6
-commands =
-
 [pep8]
 ignore = E265,E501,W504


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos