### PR TITLE
Dockerfile - Ubuntu 14->18

### DIFF
--- a/builddeb.Dockerfile
+++ b/builddeb.Dockerfile
@@ -1,4 +1,4 @@
-FROM        ubuntu:trusty
+FROM        ubuntu:bionic
 RUN         apt-get update && apt-get install -y --no-install-recommends \
                 build-essential \
                 debhelper \


### PR DESCRIPTION
Ubuntu 14 ("`trusty`") officially reached end-of-life in April, proposing using the latest long term support release, Ubuntu 18 ("`bionic`"), instead.

cc: https://ubuntu.com/about/release-cycle

_untested_